### PR TITLE
Summary and description not showing

### DIFF
--- a/django_serializer/v2/swagger/base.py
+++ b/django_serializer/v2/swagger/base.py
@@ -100,6 +100,13 @@ class Swagger:
 
         if parameters.get('requestBody', False):
             operation.update({'requestBody': parameters['requestBody']})
+
+        if getattr(meta, "description"):
+            operation.update({"description": meta.description})
+
+        if getattr(meta, "summary"):
+            operation.update({"summary": meta.summary})
+
         return {meta.method.value: operation}
 
     def _generate_paths(self):


### PR DESCRIPTION
You can specify ApiView.Meta.description and ApiView.Meta.summary but it has no effect in swagger UI


Schema produced by code
```
  /api/courses.list.by_category:
    get:
      responses:
        '200':
          description: success
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/CourseListByCategoriesSerializer'
      tags:
        - PROCESS_LANDING
        - PROCESS_COURSE
        - APPLICATION_INTERNAL
    summary: API for getting list of courses by category.
    description: Returns list of courses by category.
```

correct schema will be
```
  /api/courses.list.by_category:
    get:
      responses:
        '200':
          description: success
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/CourseListByCategoriesSerializer'
      tags:
        - PROCESS_LANDING
        - PROCESS_COURSE
        - APPLICATION_INTERNAL
      description: Returns list of courses by category.
      summary: API for getting list of courses by category.
```

Note: description and summary in method block not in path block
