### PR TITLE
Rewrite checks

### DIFF
--- a/django_serializer/apps.py
+++ b/django_serializer/apps.py
@@ -2,8 +2,10 @@ import importlib
 
 from django.apps import AppConfig
 from django.conf import settings
+from django.core import checks
 from django.urls import path
 
+from django_serializer.checks import check_registered_views
 from django_serializer.v2.swagger import views
 
 
@@ -14,3 +16,5 @@ class DjangoSerializer(AppConfig):
         urls = importlib.import_module(settings.ROOT_URLCONF)
         swagger_url = getattr(settings, 'SWAGGER_URL', 'swagger.json')
         urls.urlpatterns.append(path(swagger_url, views.index))
+
+        checks.register(check_registered_views)

--- a/django_serializer/checks.py
+++ b/django_serializer/checks.py
@@ -1,0 +1,6 @@
+def check_registered_views(app_config, **kwargs):
+    errors = []
+    for view in registered_views:
+        errors.extend(view.check(app_config, **kwargs))
+
+    return errors

--- a/django_serializer/v2/views/base.py
+++ b/django_serializer/v2/views/base.py
@@ -1,18 +1,20 @@
+import inspect
 import json
 import logging
 from json import JSONDecodeError
-from typing import Mapping, Type
+from typing import List, Mapping, Tuple, Type
 
 from django.conf import settings
+from django.core import checks
 from django.forms import Form
 from django.http import JsonResponse
 from django.views import View
 
 from django_serializer.v2.exceptions import (
-    HttpNotImplementedError,
+    BadRequestError,
     HttpError,
     HttpFormError,
-    BadRequestError,
+    HttpNotImplementedError,
     InternalServerError,
 )
 from django_serializer.v2.views.meta import ApiViewMeta
@@ -60,8 +62,10 @@ class ApiView(View, metaclass=ApiViewMeta, checkmeta=False):
                 raise HttpFormError(form)
 
     def _query_form(self):
-        self._request_query = self._form_pipeline(self.Meta.query_form,
-                                                  self.request.GET)
+        self._request_query = self._form_pipeline(
+            self.Meta.query_form,
+            self.request.GET
+            )
 
     def _body_form(self):
         body_form = self.Meta.body_form
@@ -128,3 +132,72 @@ class ApiView(View, metaclass=ApiViewMeta, checkmeta=False):
 
     def execute(self, request, *args, **kwargs):
         raise NotImplementedError
+
+    @classmethod
+    def _check_tags(cls, meta, *args, **kwargs):
+        errors = []
+
+        tags = getattr(meta, 'tags', None)
+
+        if not isinstance(tags, (List, Tuple)):
+            errors.append(
+                checks.Warning(
+                    f'`{cls.__name__}.Meta.tags` variable has incorrect type {type(tags)}',
+                    hint=f'{cls.__name__}.Meta.tags should be list or tuple',
+                    obj=cls,
+                    id='django_serializer.meta.tags.W001', )
+            )
+        else:
+            for index, item in enumerate(tags):
+                if not isinstance(item, str):
+                    errors.append(
+                        checks.Warning(
+                            f'`{cls.__name__}.Meta.tags[{index}]` variable has incorrect type {type(item)}',
+                            hint=f'{cls.__name__}.Meta.tags[{index}] should be str',
+                            obj=cls,
+                            id='django_serializer.meta.tags.W002'
+                        )
+                    )
+
+        return errors
+
+    @classmethod
+    def _check_errors(cls, meta, *args, **kwargs):
+        meta_errors = getattr(meta, 'errors', [])
+        if not meta_errors:
+            return []
+
+        errors = []
+
+        if not isinstance(meta_errors, (List, Tuple)):
+            errors.append(
+                checks.Error(
+                    f'`{cls.__name__}.Meta.errors` variable has incorrect type {type(meta_errors)}',
+                    hint=f'{cls.__name__}.Meta.errors should be list or tuple',
+                    obj=cls,
+                    id='django_serializer.meta.errors.E001',
+                )
+            )
+        else:
+            for index, item in enumerate(meta_errors):
+                if not inspect.isclass(item) or not issubclass(item, HttpError):
+                    errors.append(
+                        checks.Error(
+                            f'`{cls.__name__}.Meta.errors[{index}]` variable has incorrect type {type(item)}',
+                            hint=f'`{cls.__name__}.Meta.errors[{index}]` should be subclass of django_serializer.v2.exceptions.http.HttpError',
+                            obj=cls,
+                            id='django_serializer.meta.errors.E002',
+                        )
+                    )
+
+        return errors
+
+    @classmethod
+    def check(cls, *args, **kwargs):
+        meta = cls.Meta
+
+        errors = []
+        errors.extend(cls._check_tags(meta, *args, **kwargs))
+        errors.extend(cls._check_errors(meta, *args, **kwargs))
+
+        return errors

--- a/django_serializer/v2/views/meta.py
+++ b/django_serializer/v2/views/meta.py
@@ -45,7 +45,6 @@ class ApiViewMeta(type):
             base_options = mcs.find_base_options(bases)
             meta = mcs.merge_options(options, base_options)
             errors = []
-            mcs.check_meta_extra(meta, errors)
             mj, mn = sys.version_info[:2]
             if mj >= 3 and mn >= 7:
                 mcs.check_meta(meta, errors)
@@ -84,36 +83,6 @@ class ApiViewMeta(type):
                 annt = cls.__annotations__.get(name)
                 if annt is not None:
                     return annt
-
-    @classmethod
-    def check_meta_extra(mcs, meta: Type, errors: List):
-        tags = getattr(meta, 'tags', None)
-        if not tags:
-            errors.append('`tags` is required')
-        else:
-            if not isinstance(tags, List):
-                errors.append('`tags` variable has incorrect type, '
-                              'should be list')
-            else:
-                if any([not isinstance(item, str) for item in tags]):
-                    errors.append('`tags` item has incorrect type, '
-                                  'should be str')
-
-        meta_errors = getattr(meta, 'errors', [])
-        if meta_errors:
-            if not isinstance(meta_errors, List):
-                errors.append('`errors` variable has incorrect type, '
-                              'should be list')
-            else:
-                try:
-                    if any([not issubclass(item, HttpError)
-                            for item in meta_errors]):
-                        raise TypeError
-                except TypeError:
-                    errors.append('`errors` item has incorrect type, '
-                                  'should be subtype of HttpError')
-
-        return errors
 
     @classmethod
     def check_meta(mcs, meta: Type, errors: List):

--- a/tests/django_serializer/views/test_base.py
+++ b/tests/django_serializer/views/test_base.py
@@ -1,4 +1,7 @@
+from typing import Sequence, Type, Union
+
 import pytest
+from django.core import checks
 from django.forms import Form
 
 from django_serializer.v2.exceptions import (
@@ -11,18 +14,24 @@ from django_serializer.v2.views import ApiView, HttpMethod
 
 class TestMeta:
     @staticmethod
-    def _create_meta(attrs):
+    def _create_view(attrs)  -> Type[ApiView]:
+        class View(ApiView):
+            class Meta:
+                for k, v in attrs.items():
+                    locals()[k] = v
+
+        return View
+
+    @staticmethod
+    def _create_meta(attrs) -> Sequence[str]:
         try:
-            class View(ApiView):
-                class Meta:
-                    for k, v in attrs.items():
-                        locals()[k] = v
+            TestMeta._create_view(attrs)
         except IncorrectMetaException as e:
             return e.errors
 
     def test_empty(self):
         errors = self._create_meta({})
-        assert errors == ['`tags` is required', '`method` is required']
+        assert errors == ['`method` is required']
 
     def test_method(self):
         errors = self._create_meta({'tags': ['tags'], 'method': 'get'})
@@ -31,14 +40,58 @@ class TestMeta:
         ]
 
     @pytest.mark.parametrize('tags, expected_errors', [
-        (None, ['`tags` is required']),
-        ([], ['`tags` is required']),
-        ([1], ['`tags` item has incorrect type, should be str']),
-        (['t'], None),
+        (None, [
+            checks.Warning(
+                f'`View.Meta.tags` variable has incorrect type {type(None)}',
+                hint='View.Meta.tags should be list or tuple',
+                id='django_serializer.meta.tags.W001'
+            )
+        ]),
+        ([1], [
+            checks.Warning(
+                f'`View.Meta.tags[0]` variable has incorrect type {type(1)}',
+                hint='View.Meta.tags[0] should be str',
+                id='django_serializer.meta.tags.W002'
+            )
+        ]),
+        (['t'], []),
     ])
     def test_tags(self, tags, expected_errors):
-        errors = self._create_meta({'tags': tags, 'method': HttpMethod.GET})
-        assert errors == expected_errors
+        view = self._create_view({'tags': tags, 'method': HttpMethod.GET})
+
+        for error in expected_errors:
+            error.obj = view
+        assert view.check() == expected_errors
+
+    @pytest.mark.parametrize('errors, expected_errors', [
+        (None, [],),
+        (1, [
+            checks.Error(
+                f'`View.Meta.errors` variable has incorrect type {type(1)}',
+                hint='View.Meta.errors should be list or tuple',
+                id='django_serializer.meta.errors.E001'
+            )
+        ]),
+        ([Exception, 1], [
+            checks.Error(
+                f'`View.Meta.errors[0]` variable has incorrect type {type(Exception)}',
+                hint='`View.Meta.errors[0]` should be subclass of django_serializer.v2.exceptions.http.HttpError',
+                id='django_serializer.meta.errors.E002'
+            ),
+            checks.Error(
+                f'`View.Meta.errors[1]` variable has incorrect type {type(1)}',
+                hint='`View.Meta.errors[1]` should be subclass of django_serializer.v2.exceptions.http.HttpError',
+                id='django_serializer.meta.errors.E002'
+            )
+        ]),
+        ([BadRequestError], []),
+    ])
+    def test_errors(self, errors, expected_errors):
+        view = self._create_view({'errors': errors, 'method': HttpMethod.GET})
+
+        for error in expected_errors:
+            error.obj = view
+        assert view.check() == expected_errors
 
     @pytest.mark.parametrize('field, value, expected_errors', [
         ('summary', 1, ['`summary` has incorrect type, '
@@ -87,9 +140,6 @@ class TestMeta:
                                   "should be `<class 'bool'>`"]),
         ('serializer_many', True, None),
 
-        ('errors', [Exception, 1], ['`errors` item has incorrect type, '
-                                    'should be subtype of HttpError']),
-        ('errors', [BadRequestError], None),
     ])
     def test_var(self, field, value, expected_errors):
         errors = self._create_meta({'tags': ['tags'], 'method': HttpMethod.GET,


### PR DESCRIPTION
Problem:
IncorrectMetaException prevents collecting all errors from views. Also kills development server reload

Solution:
IncorrectMetaException changed to internal django checks mechanism.

